### PR TITLE
Fix a few typos

### DIFF
--- a/annotations/yo/intro/c17features.yo
+++ b/annotations/yo/intro/c17features.yo
@@ -127,7 +127,7 @@ thread_local, mutable) and tt(static)).
 dit([[maybe_unused]])hi(maybe_unused)
 
     This attribute can be applied to a class, typedef-name, variable,
-non-static fata member, a function, an enumeration or an enumerator. When it
+non-static data member, a function, an enumeration or an enumerator. When it
 is applied to an entity no warning is generated if the entity whether the
 entity is used or is not used. Example:
         verb(

--- a/annotations/yo/intro/c17features.yo
+++ b/annotations/yo/intro/c17features.yo
@@ -60,7 +60,7 @@ expressions, or function calls:
         )
     In addition, when overloading an operator, the function implementing the
 overloaded operator is evaluated like the built-in operator it overloads, and
-not in the way function call are ordered in general.
+not in the way function calls are ordered in general.
 
 dit([[fallthrough]])hi(fallthrough)
 

--- a/annotations/yo/intro/c17features.yo
+++ b/annotations/yo/intro/c17features.yo
@@ -149,7 +149,7 @@ dit([[nodiscard]])hi(nodiscard)
 function, class or enumeration. If a function is declared tt([[nodiscard]]) or
 if a function returns an entity previously declared using tt([[nodiscard]])
 then the return value of such a function may only be ignored when explicitly
-cast to void. Otherwise, when the return value is not used as warning is
+cast to void. Otherwise, when the return value is not used a warning is
 issued. Example:
         verb(
 int [[nodiscard]] importantInt();

--- a/annotations/yo/intro/c17features.yo
+++ b/annotations/yo/intro/c17features.yo
@@ -60,7 +60,7 @@ expressions, or function calls:
         )
     In addition, when overloading an operator, the function implementing the
 overloaded operator is evaluated like the built-in operator it overloads, and
-not in the way function call are ordered in genereal.
+not in the way function call are ordered in general.
 
 dit([[fallthrough]])hi(fallthrough)
 

--- a/annotations/yo/intro/c17features.yo
+++ b/annotations/yo/intro/c17features.yo
@@ -128,8 +128,8 @@ dit([[maybe_unused]])hi(maybe_unused)
 
     This attribute can be applied to a class, typedef-name, variable,
 non-static data member, a function, an enumeration or an enumerator. When it
-is applied to an entity no warning is generated if the entity whether the
-entity is used or is not used. Example:
+is applied to an entity no warning is generated whether the entity is used or
+is not used. Example:
         verb(
 void fun([[maybe_unused]] size_t argument)
 {


### PR DESCRIPTION
Whilst reading the book, I stumbled upon a few typos in the Intro section about upcoming C++17 features.

English is not my native tongue, so I might have mistaken something for a typo, when it was in fact correct, so please check my 'corrections'.

If you want to, I can squash the commits together, but I separated each 'fix' into its own commit lest one of those was actually a [verschlimmbesserung](https://www.urbandictionary.com/define.php?term=Verschlimmbesserung)

Additionally I want to thank you for your hard work, the book is a treasure trove of information!