### PR TITLE
Fix link

### DIFF
--- a/README
+++ b/README
@@ -4,4 +4,4 @@
 The C++ Annotation's repository has moved to https://gitlab.com/fbb-git/cppannotations
 and is not maintained at this location anymore.
 
-The project's web-page can be found at http://fbb-git.gitlab.io/cppannotations/</a>
+The project's web-page can be found at http://fbb-git.gitlab.io/cppannotations


### PR DESCRIPTION
fix link. for whatever reason, there is a html ending marker in this text; this breaks the link to the web page.